### PR TITLE
Fix: increase contract test agent token limit

### DIFF
--- a/.github/scripts/contract-test-agent.mjs
+++ b/.github/scripts/contract-test-agent.mjs
@@ -135,7 +135,7 @@ async function callClaude() {
     },
     body: JSON.stringify({
       model: 'claude-sonnet-4-20250514',
-      max_tokens: 8192,
+      max_tokens: 16384,
       system: systemPrompt,
       messages: [
         { role: 'user', content: userPrompt },


### PR DESCRIPTION
Response was truncating at 8192 tokens.